### PR TITLE
Update link for Alternative Checkboxes reference set

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Valid colors include all the default rainbow colors included in Obsidian by defa
 
 - [x] Several color schemes for light and dark mode
 - [x] Full support for mobile devices
-- [ ] Partial implementation of Damian Korcz's **[Alternative Checkboxes](github.com/damiankorcz/Alternative-Checkboxes-Reference-Set)** reference set
+- [ ] Partial implementation of Damian Korcz's **[Alternative Checkboxes](https://github.com/damiankorcz/Alternative-Checkboxes-Reference-Set)** reference set
 
 <br>
 


### PR DESCRIPTION
I noticed that the existing link in the README is interpreted as being relative, so clicking on it takes you to an invalid URL within this repo. By adding the protocol, the link works!